### PR TITLE
Switch to using extra_state_attributes

### DIFF
--- a/custom_components/radarr_upcoming_media/sensor.py
+++ b/custom_components/radarr_upcoming_media/sensor.py
@@ -73,7 +73,7 @@ class RadarrUpcomingMediaSensor(Entity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         attributes = {}
         if self.change_detected:
             """Return JSON for the sensor."""


### PR DESCRIPTION
Users will start to get warned about integrations that use `device_state_attributes` in 2021.12.0