### PR TITLE
Removed "domain" from hacs.json to avoid HACS validation workflow error.

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,4 @@
 {
     "name": "Radarr Upcoming Media",
-    "content_in_root": false,
-    "domains": ["sensor"]
+    "content_in_root": false
 }


### PR DESCRIPTION
Removed "domain" from hacs.json to avoid HACS validation workflow error.