### PR TITLE
Fix

### DIFF
--- a/custom_components/radarr_upcoming_media/radarr_api.py
+++ b/custom_components/radarr_upcoming_media/radarr_api.py
@@ -46,7 +46,7 @@ class RadarrApi():
             's' if self._ssl else '', 
             self._host,
             self._port,
-            '{}/'.format(self._urlbase.strip('/') if self._urlbase else self._urlbase),
+            '{}/'.format(self._urlbase.strip('/')) if self._urlbase else self._urlbase,
             start, 
             end
         )


### PR DESCRIPTION
- issue with missplaced bracked results in not being able to parse api.json()